### PR TITLE
crypto/lyra2.h: fix "multiple definition of `lyra2_hash'" build failure

### DIFF
--- a/src/crypto/Lyra2.h
+++ b/src/crypto/Lyra2.h
@@ -56,7 +56,7 @@ extern "C" {
     void LYRA2_destroy(void *c);
 
 
-    inline void lyra2_hash(const uint8_t *input, size_t size, uint8_t *output, void *ctx)
+    static inline void lyra2_hash(const uint8_t *input, size_t size, uint8_t *output, void *ctx)
     {
     	LYRA2(ctx, output, 32, input, size);
     }


### PR DESCRIPTION
Fix "multiple definition of `lyra2_hash'" build error with older compilers (Centos 7):
```
CMakeFiles/webchain-miner.dir/src/crypto/Sponge.c.o: In function `lyra2_hash':
Sponge.c:(.text+0x0): multiple definition of `lyra2_hash'
CMakeFiles/webchain-miner.dir/src/crypto/Lyra2.c.o:Lyra2.c:(.text+0x280): first defined here
collect2: error: ld returned 1 exit status
```